### PR TITLE
Add a "keep-versions" parameter.

### DIFF
--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -26,6 +26,7 @@ import errno
 import logging
 import os
 import re
+import shutil
 import tarfile
 import threading
 
@@ -42,6 +43,7 @@ arg_symlink = None
 arg_webhook_token = None
 arg_api_token = None
 arg_artifact_pattern = None
+arg_keep_versions = None
 
 deploy_lock = threading.Lock()
 
@@ -168,6 +170,8 @@ def on_receive_buildkite_poke():
         with deploy_lock:
             logger.info("Got deploy lock; deploying to %s", target_dir)
             deploy_tarball(url, target_dir)
+            if args_keep_versions is not None:
+                tidy_old_versions(target_dir, pipeline_name)
 
     threading.Thread(target=deploy).start()
 
@@ -195,6 +199,24 @@ def deploy_tarball(artifact_url, target_dir):
     logger.info("...download complete.")
 
     create_symlink(source=target_dir, linkname=arg_symlink)
+    
+
+def tidy_extract_directory(target_dir, pipeline_name):
+    """
+    Remove all but the last count versions in the directory.
+    Will never remove the target_dir as we just deployed it.
+    Will only consider directories that match pipeline_name.
+    """
+    directories = glob.glob(args_extract_directory + "/" + pipeline_name + "*")
+  
+    directories.sort(key = lambda x: os.path.getmtime(x))
+    to_delete = directories[:-arg_keep_versions]
+
+    for target in to_delete:
+        if target != target_dir: 
+            shutil.rmtree(target)
+        
+
 
 
 if __name__ == "__main__":
@@ -248,13 +270,25 @@ if __name__ == "__main__":
         )
     )
 
+    parser.add_argument(
+        "--keep-versions", help=(
+            "Retain only this number of versions on disk. Set to a positive "
+            "integer. Defaults to keeping all versions."
+        )
+    )
+
     args = parser.parse_args()
+
+    if args.keep_versions is not None and args.keep_versions < 1:
+        parser.error("keep-versions should be unset or > 0")
+
     arg_extract_path = args.extract
     arg_symlink = args.symlink
     arg_webbook_token = args.webhook_token
     arg_api_token = args.api_token
     arg_buildkite_org = args.buildkite_org
     arg_artifact_pattern = args.artifact_pattern
+    arg_keep_versions = args.keep_versions
 
     if not os.path.isdir(arg_extract_path):
         os.mkdir(arg_extract_path)
@@ -268,4 +302,12 @@ if __name__ == "__main__":
         ),
         flush=True,
     )
+    if arg_keep_versions is not None:
+        print(
+            "Keeping only previous %s versions." % ( arg_keep_versions ),
+            flush=True,
+        )
+    else:
+        print("Keeping all versions") 
+
     app.run(port=args.port, debug=False)

--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -301,7 +301,7 @@ if __name__ == "__main__":
     )
     if arg_keep_versions is not None:
         print(
-            "Keeping only previous %s versions." % ( arg_keep_versions ),
+            "Keeping only previous %i versions." % (arg_keep_versions, ),
             flush=True,
         )
     else:

--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -170,8 +170,8 @@ def on_receive_buildkite_poke():
         with deploy_lock:
             logger.info("Got deploy lock; deploying to %s", target_dir)
             deploy_tarball(url, target_dir)
-            if args_keep_versions is not None:
-                tidy_old_versions(target_dir, pipeline_name)
+            if arg_keep_versions is not None:
+                tidy_extract_directory(target_dir, pipeline_name)
 
     threading.Thread(target=deploy).start()
 
@@ -207,7 +207,7 @@ def tidy_extract_directory(target_dir, pipeline_name):
     Will never remove the target_dir as we just deployed it.
     Will only consider directories that match pipeline_name.
     """
-    directories = glob.glob(args_extract_directory + "/" + pipeline_name + "*")
+    directories = glob.glob(args_extract_directory + "/" + pipeline_name + "-#*")
   
     directories.sort(key = lambda x: os.path.getmtime(x))
     to_delete = directories[:-arg_keep_versions]
@@ -216,9 +216,6 @@ def tidy_extract_directory(target_dir, pipeline_name):
         if target != target_dir: 
             shutil.rmtree(target)
         
-
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Runs a redeployment server.")
     parser.add_argument(

--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -203,9 +203,9 @@ def deploy_tarball(artifact_url, target_dir):
 
 def tidy_extract_directory(target_dir, pipeline_name):
     """
-    Remove all but the last count versions in the directory.
-    Will never remove the target_dir as we just deployed it.
-    Will only consider directories that match pipeline_name.
+    Remove all but the last arg_keep_versions in the directory.
+    Will never remove the target_dir that we just deployed.
+    Will only consider directories that match the pattern.
     """
     directories = glob.glob(args_extract_directory + "/" + pipeline_name + "-#*")
   

--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -171,7 +171,7 @@ def on_receive_buildkite_poke():
             logger.info("Got deploy lock; deploying to %s", target_dir)
             deploy_tarball(url, target_dir)
             if arg_keep_versions is not None:
-                tidy_extract_directory(target_dir, pipeline_name)
+                tidy_extract_directory(target_dir)
 
     threading.Thread(target=deploy).start()
 
@@ -201,11 +201,14 @@ def deploy_tarball(artifact_url, target_dir):
     create_symlink(source=target_dir, linkname=arg_symlink)
     
 
-def tidy_extract_directory(target_dir, pipeline_name):
+def tidy_extract_directory(target_dir):
     """
     Remove all but the last arg_keep_versions in the directory.
     Will never remove the target_dir that we just deployed.
     Will only consider directories that match the pattern.
+
+    Args:
+       target_dir: absolute path to the directory where files are unpacked
     """
     directories = glob.glob(args_extract_directory + "/*-#*")
   

--- a/buildkite-webhook-listener.py
+++ b/buildkite-webhook-listener.py
@@ -207,7 +207,7 @@ def tidy_extract_directory(target_dir, pipeline_name):
     Will never remove the target_dir that we just deployed.
     Will only consider directories that match the pattern.
     """
-    directories = glob.glob(args_extract_directory + "/" + pipeline_name + "-#*")
+    directories = glob.glob(args_extract_directory + "/*-#*")
   
     directories.sort(key = lambda x: os.path.getmtime(x))
     to_delete = directories[:-arg_keep_versions]
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--keep-versions", help=(
+        "--keep-versions", type=int, help=(
             "Retain only this number of versions on disk. Set to a positive "
             "integer. Defaults to keeping all versions."
         )


### PR DESCRIPTION
If set, tidy up disk after extraction to manage space.

Partially fixes #1 